### PR TITLE
Prepare for the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   * `path` files or directory to transform
   * `--dry` option for a dry-run
   * `--print` option to print the output for comparison
-  
+
 #### Example
 
 ```sh
@@ -15,15 +15,15 @@ npx date-fns-codemod src/
 
 ### Codemods applied
 
-*N.B.* At the moment this codemod applies fixes ONLY for first 3 points of 
+*N.B.* At the moment this codemod applies fixes ONLY for first 3 points of
 2.0 date-fns [CHANGELOG](https://github.com/date-fns/date-fns/blob/master/CdHANGELOG.md#changed)\
 You'll have to take care of all the other breaking changes.
 
-Codemod imports required tools from `date-fns-upgrade` and wraps
+Codemod imports required tools from `@date-fns/upgrade` and wraps
 `date-fns` function call arguments accordingly.
 
 ```diff
-+import { legacyParse, legacyParseMap, convertTokens } from 'date-fns-upgrade'
++import { legacyParse, legacyParseMap, convertTokens } from '@date-fns/upgrade/v2'
 
  const dateIs = '2019-07-01'
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "date-fns-codemod",
+  "name": "@date-fns/upgrade-codemod",
   "version": "1.0.0",
   "description": "date-fns codemod 1.x -> 2.0",
   "main": "src/transform.ts",
@@ -13,7 +13,7 @@
     "meow": "^5.0.0"
   },
   "devDependencies": {
-    "@date-fns/upgrade": "^1.0.0-beta.1",
+    "@date-fns/upgrade": "^1.0.0-beta.2",
     "@types/execa": "^2.0.0",
     "@types/inquirer": "^6.5.0",
     "@types/jest": "^24.0.15",

--- a/src/tests/fixtures/importDefaultSpecifier.output.js
+++ b/src/tests/fixtures/importDefaultSpecifier.output.js
@@ -1,6 +1,6 @@
 import dateFns from 'date-fns'
 
-import { legacyParse, legacyParseMap } from 'date-fns-upgrade'
+import { legacyParse, legacyParseMap } from '@date-fns/upgrade/v2'
 
 const dateIs = '2019-07-01'
 

--- a/src/tests/fixtures/importDefaultSpecifierSubmodule.output.js
+++ b/src/tests/fixtures/importDefaultSpecifierSubmodule.output.js
@@ -3,11 +3,15 @@ import closestToIndex from 'date-fns/closestToIndex'
 import addSeconds from 'date-fns/addSeconds'
 import getThatDay from 'date-fns/getISODay'
 
-import { legacyParse, legacyParseMap, convertTokens } from 'date-fns-upgrade'
+import {
+  legacyParse,
+  legacyParseMap,
+  convertTokens
+} from '@date-fns/upgrade/v2'
 
 const dateIs = '2019-07-01'
 
-const someToken = 'MM-DD';
+const someToken = 'MM-DD'
 const format = importedFormat(
   legacyParse('2019-07-01'),
   convertTokens(someToken)

--- a/src/tests/fixtures/importNamespaceSpecifier.output.js
+++ b/src/tests/fixtures/importNamespaceSpecifier.output.js
@@ -1,6 +1,10 @@
 import * as dateFnsOrNotFns from 'date-fns'
 
-import { legacyParse, legacyParseMap, convertTokens } from 'date-fns-upgrade'
+import {
+  legacyParse,
+  legacyParseMap,
+  convertTokens
+} from '@date-fns/upgrade/v2'
 
 const dateIs = '2019-07-01'
 

--- a/src/tests/fixtures/importSpecifier.output.js
+++ b/src/tests/fixtures/importSpecifier.output.js
@@ -1,6 +1,6 @@
 import { format as importedFormat, closestToIndex, addSeconds } from 'date-fns'
 
-import { legacyParse, legacyParseMap } from 'date-fns-upgrade'
+import { legacyParse, legacyParseMap } from '@date-fns/upgrade/v2'
 
 const dateIs = '2019-07-01'
 const someToken = 'MM-DD'

--- a/src/tests/fixtures/objectProperty.output.js
+++ b/src/tests/fixtures/objectProperty.output.js
@@ -1,9 +1,6 @@
 const { format, closestToIndex, addSeconds } = require('date-fns')
 
-const {
-  legacyParse,
-  legacyParseMap,
-} = require('date-fns-upgrade')
+const { legacyParse, legacyParseMap } = require('@date-fns/upgrade/v2')
 
 const dateIs = '2019-07-01'
 

--- a/src/tests/fixtures/variableDeclarator.output.js
+++ b/src/tests/fixtures/variableDeclarator.output.js
@@ -1,13 +1,10 @@
 const dateFns = require('date-fns')
 
-const { legacyParse, legacyParseMap } = require('date-fns-upgrade')
+const { legacyParse, legacyParseMap } = require('@date-fns/upgrade/v2')
 
 const dateIs = '2019-07-01'
 
-const formatMePlease = dateFns.format(
-  legacyParse('2019-07-01'),
-  "LL'-'dd"
-)
+const formatMePlease = dateFns.format(legacyParse('2019-07-01'), "LL'-'dd")
 const closestIndex = dateFns.closestToIndex(
   legacyParse(new Date(2015, 8, 6)),
   legacyParseMap([

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,7 +1,7 @@
 import { camelCase } from 'change-case'
-import { v2 } from '@date-fns/upgrade'
-import transformImports from "transform-imports";
-import * as functionData from "./data/functionData.json";
+import { convertTokens } from '@date-fns/upgrade/v2'
+import transformImports from 'transform-imports'
+import * as functionData from './data/functionData.json'
 
 import { API, FileInfo, Literal, Options } from 'jscodeshift/src/core'
 import { CodeMap } from './utils/parse'
@@ -69,7 +69,7 @@ const dateFnsCodemod = (fileInfo: FileInfo, api: API, options: Options) => {
    */
   const codeWithTransformedImports = transformImports(
     fileInfo.source,
-    (importDefs) => {
+    importDefs => {
       importDefs
         .filter(({ source }) => (source || '').includes('date-fns'))
         .filter(({ variableName }) => variableName !== undefined)
@@ -154,7 +154,7 @@ const dateFnsCodemod = (fileInfo: FileInfo, api: API, options: Options) => {
       argumentNode.type === 'Literal' &&
       typeof argumentNode.value === 'string'
     )
-      return j.literal(v2.convertTokens(argumentNode.value))
+      return j.literal(convertTokens(argumentNode.value))
 
     usedLegacyUpgrades[legacyHelperFunctionName] = true
 
@@ -231,7 +231,7 @@ const dateFnsCodemod = (fileInfo: FileInfo, api: API, options: Options) => {
   })
 
   /**
-   * As a last step we add import of all `date-fns-upgrade` tools used
+   * As a last step we add import of all `@date-fns/upgrade` tools used
    */
   const usedLegacyUpgradesEntries = Object.entries(usedLegacyUpgrades).filter(
     ([_, value]) => value
@@ -270,7 +270,7 @@ const dateFnsCodemod = (fileInfo: FileInfo, api: API, options: Options) => {
           usedLegacyUpgrades.map(value =>
             j.importSpecifier(j.identifier(value))
           ),
-          j.stringLiteral('date-fns-upgrade')
+          j.stringLiteral('@date-fns/upgrade/v2')
         )
       )
     } else if (variableDeclarationCollection.size()) {
@@ -289,7 +289,7 @@ const dateFnsCodemod = (fileInfo: FileInfo, api: API, options: Options) => {
               })
             ),
             j.callExpression(j.identifier('require'), [
-              j.literal('date-fns-upgrade')
+              j.literal('@date-fns/upgrade/v2')
             ])
           )
         ])

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,10 +732,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@date-fns/upgrade@^1.0.0-beta.1":
-  version "1.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@date-fns/upgrade/-/upgrade-1.0.0-beta.1.tgz#95769869acc035936e5665b0ed91e1b2a7764f3d"
-  integrity sha512-XDZ2yDJbwDRNNwWDi91GN5LIwZCEIVCP/OBCJ+14Pj2p5mzuHRl4tFrQg0lhCXSd7eNKGFyDyJZ/eusR5SqY+A==
+"@date-fns/upgrade@^1.0.0-beta.2":
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@date-fns/upgrade/-/upgrade-1.0.0-beta.2.tgz#9bfe69f9f91ef77b25ef3819ce3c26bea3817890"
+  integrity sha512-uB2gCZCKsPN59MFE5Xldi53fvr0LIsmSKUlcRobWnCh84BNJdONAcdyVOXZprNnUvOx9SW6jc6QP+Nt/SmPDSA==
   dependencies:
     date-fns "^2.0.0-beta.4"
 


### PR DESCRIPTION
- Rename the package to `@date-fns/upgrade-codemod`
- Upgrade and use `@date-fns/upgrade` package instead of `date-fns-upgrade`