### PR TITLE
Fix URL to date-fns changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npx @date-fns/upgrade-codemod src/
 ### Codemods applied
 
 *N.B.* At the moment this codemod applies fixes ONLY for first 3 points of
-2.0 date-fns [CHANGELOG](https://github.com/date-fns/date-fns/blob/master/CdHANGELOG.md#changed)\
+2.0 date-fns [CHANGELOG](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#changed)\
 You'll have to take care of all the other breaking changes.
 
 Codemod imports required tools from `@date-fns/upgrade` and wraps


### PR DESCRIPTION
The URL to the date-fns repo's changelog is incorrect. This PR fixes it.